### PR TITLE
Fix for C++17 and later

### DIFF
--- a/src/include/smash/cxx14compat.h
+++ b/src/include/smash/cxx14compat.h
@@ -21,11 +21,14 @@ namespace smash {
  *
  * \see http://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
  */
+#if __cplusplus < 201402L
 template <typename T, typename... Args>
 inline std::unique_ptr<T> make_unique(Args &&... args) {
   return std::unique_ptr<T>{new T{std::forward<Args>(args)...}};
 }
-
+#else
+  using std::make_unique;
+#endif
 }  // namespace smash
 
 #endif  // SRC_INCLUDE_SMASH_CXX14COMPAT_H_


### PR DESCRIPTION
Protect definition of compatbility `make_unique` with preprocessor guards
to avoid conflicting definitions for C++17 or later