### PR TITLE
Rename macro `source_location` to `SMASH_SOURCE_LOCATION`

### DIFF
--- a/src/experiment.cc
+++ b/src/experiment.cc
@@ -22,7 +22,7 @@ namespace smash {
 /* ExperimentBase carries everything that is needed for the evolution */
 ExperimentPtr ExperimentBase::create(Configuration config,
                                      const bf::path &output_path) {
-  logg[LExperiment].trace() << source_location;
+  logg[LExperiment].trace() << SMASH_SOURCE_LOCATION;
   /*!\Userguide
    * \page input_general_ General
    * \key Modus (string, required): \n
@@ -333,7 +333,7 @@ ExperimentPtr ExperimentBase::create(Configuration config,
  */
 
 ExperimentParameters create_experiment_parameters(Configuration config) {
-  logg[LExperiment].trace() << source_location;
+  logg[LExperiment].trace() << SMASH_SOURCE_LOCATION;
 
   const int ntest = config.take({"General", "Testparticles"}, 1);
   if (ntest <= 0) {

--- a/src/fpenvironment.cc
+++ b/src/fpenvironment.cc
@@ -127,10 +127,10 @@ void setup_default_float_traps() {
           msg = "unknown";
           break;
       }
-      logg[LFpe].fatal(source_location,
+      logg[LFpe].fatal(SMASH_SOURCE_LOCATION,
                        "Floating point trap was raised: ", msg);
     } else {
-      logg[LFpe].fatal(source_location, "Unexpected Signal ", signal,
+      logg[LFpe].fatal(SMASH_SOURCE_LOCATION, "Unexpected Signal ", signal,
                        " received in the FPE signal handler. Aborting.");
     }
     std::abort();

--- a/src/grid.cc
+++ b/src/grid.cc
@@ -253,7 +253,7 @@ Grid<O>::Grid(const std::pair<std::array<double, 3>, std::array<double, 3>>
 #ifndef NDEBUG
         if (idx >= SizeType(cells_.size())) {
           logg[LGrid].fatal(
-              source_location,
+              SMASH_SOURCE_LOCATION,
               "\nan out-of-bounds access would be necessary for the "
               "particle ",
               p, "\nfor a grid with the following parameters:\nmin: ",

--- a/src/include/smash/action.h
+++ b/src/include/smash/action.h
@@ -389,7 +389,7 @@ class Action {
       }
     }
     /* Should never get here. */
-    logg[LAction].fatal(source_location,
+    logg[LAction].fatal(SMASH_SOURCE_LOCATION,
                         "Problem in choose_channel: ", subprocesses.size(), " ",
                         weight_sum, " ", total_weight, " ",
                         //          random_weight, "\n", *this);

--- a/src/include/smash/experiment.h
+++ b/src/include/smash/experiment.h
@@ -966,7 +966,7 @@ Experiment<Modus>::Experiment(Configuration config, const bf::path &output_path)
    **/
 
   // create outputs
-  logg[LExperiment].trace(source_location, " create OutputInterface objects");
+  logg[LExperiment].trace(SMASH_SOURCE_LOCATION, " create OutputInterface objects");
 
   auto output_conf = config["Output"];
   /*!\Userguide

--- a/src/include/smash/logging.h
+++ b/src/include/smash/logging.h
@@ -240,8 +240,8 @@ void create_all_loggers(Configuration config);
  * Hackery that is required to output the location in the source code where the
  * log statement occurs.
  */
-#define source_location \
-  __FILE__ ":" + std::to_string(__LINE__) + " (" + __func__ + ')'
+#define SMASH_SOURCE_LOCATION						\
+   __FILE__ ":" + std::to_string(__LINE__) + " (" + __func__ + ')'
 
 /**
  * \return The default log level to use if no specific level is configured.

--- a/src/include/smash/outputparameters.h
+++ b/src/include/smash/outputparameters.h
@@ -43,7 +43,7 @@ struct OutputParameters {
 
   /// Constructor from configuration
   explicit OutputParameters(Configuration&& conf) : OutputParameters() {
-    logg[LExperiment].trace(source_location);
+    logg[LExperiment].trace(SMASH_SOURCE_LOCATION);
 
     if (conf.has_value({"Thermodynamics"})) {
       auto subcon = conf["Thermodynamics"];

--- a/src/inputfunctions.cc
+++ b/src/inputfunctions.cc
@@ -19,7 +19,7 @@ namespace smash {
 static constexpr int LInputParser = LogArea::InputParser::id;
 
 std::vector<Line> line_parser(const std::string &input) {
-  logg[LInputParser].trace() << source_location << input;
+  logg[LInputParser].trace() << SMASH_SOURCE_LOCATION << input;
   std::istringstream input_stream(input);
   std::vector<Line> lines;
   lines.reserve(50);

--- a/src/smash.cc
+++ b/src/smash.cc
@@ -548,7 +548,7 @@ int main(int argc, char *argv[]) {
     // check if version matches before doing anything else
     check_config_version_is_compatible(configuration);
 
-    logg[LMain].trace(source_location, " create ParticleType and DecayModes");
+    logg[LMain].trace(SMASH_SOURCE_LOCATION, " create ParticleType and DecayModes");
 
     auto particles_and_decays =
         load_particles_and_decaymodes(particles, decaymodes);
@@ -747,11 +747,11 @@ int main(int argc, char *argv[]) {
         << "# Build    : " << CMAKE_BUILD_TYPE << '\n'
         << "# Date     : " << BUILD_DATE << '\n'
         << configuration.to_string() << '\n';
-    logg[LMain].trace(source_location, " create ParticleType and DecayModes");
+    logg[LMain].trace(SMASH_SOURCE_LOCATION, " create ParticleType and DecayModes");
     initialize_particles_and_decays(configuration, hash, tabulations_path);
 
     // Create an experiment
-    logg[LMain].trace(source_location, " create Experiment");
+    logg[LMain].trace(SMASH_SOURCE_LOCATION, " create Experiment");
     auto experiment = ExperimentBase::create(configuration, output_path);
 
     // Version value is not used in experiment. Get rid of it to prevent
@@ -760,7 +760,7 @@ int main(int argc, char *argv[]) {
     check_for_unused_config_values(configuration);
 
     // Run the experiment
-    logg[LMain].trace(source_location, " run the Experiment");
+    logg[LMain].trace(SMASH_SOURCE_LOCATION, " run the Experiment");
     experiment->run();
   } catch (std::exception &e) {
     logg[LMain].fatal() << "SMASH failed with the following error:\n"
@@ -768,6 +768,6 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
-  logg[LMain].trace() << source_location << " about to return from main";
+  logg[LMain].trace() << SMASH_SOURCE_LOCATION << " about to return from main";
   return 0;
 }


### PR DESCRIPTION
The macro that expands to `__FILE__` and `__LINENO__` is renamed to
`SMASH_SOURCE_LOCATION` (from `source_location`) to not cause
compilation trouble because of `boost::source_location` being
implicitly included.