### PR TITLE
Various fixes for better 3rd party use of SMASH

### DIFF
--- a/src/collidermodus.cc
+++ b/src/collidermodus.cc
@@ -43,21 +43,28 @@ static constexpr int LCollider = LogArea::Collider::id;
  * the projectile nucleus (in AGeV). This assumes the target nucleus is at rest.
  * Note, this can also be given per-beam.
  *
+ * \li \key E_Tot (double, optional, no default): \n
+ * Defines the energy of the collision by the total energy per nucleon of
+ * the projectile nucleus (in AGeV). This assumes the target nucleus is at rest.
+ * Note, this can also be given per-beam.
+ *
  * \li \key P_Lab (double, optional, no default): \n
  * Defines the energy of the collision by the initial momentum per nucleon
  * of the projectile nucleus (in AGeV). This assumes the target nucleus is at
- * rest.  Note, this can also be given per-beam.
+ * rest.  This must be positive.  Note, this can also be given per-beam.
  *
  * \li Alternatively, one can specify the individual beam energies or
- * momenta in the * \key Projectile and \key Target sections.  Note,
- * one must give either \key E_Kin for both \key Projectile and \key
- * Target or \key P_Lab for both \key Projectile and \key Target.
+ * momenta in the \key Projectile and \key Target sections.  Note,
+ * one must give either \key E_Tot for both \key Projectile and \key
+ * Target, \key E_Kin for both \key Projectile and \key
+ * Target, or \key P_Lab for both \key Projectile and \key Target.
 
- * Note that using \key E_kin or \key P_Lab to quantify the collision energy is
- * not sufficient to configure a collision in a fixed target frame. You need to
- * additionally change the \key Calculation_Frame. Any format of incident energy
- * can however be combined with any calculation frame, the provided incident
- * energy is then intrinsically translated to the quantity needed for the
+ * Note that using \key E_Tot, \key E_kin or \key P_Lab to quantify
+ * the collision energy is not sufficient to configure a collision in
+ * a fixed target frame. You need to additionally change the \key
+ * Calculation_Frame. Any format of incident energy can however be
+ * combined with any calculation frame, the provided incident energy
+ * is then intrinsically translated to the quantity needed for the
  * computation.
  *
  * \key Calculation_Frame (string, optional, default = "center of velocity"): \n
@@ -128,20 +135,26 @@ static constexpr int LCollider = LogArea::Collider::id;
  * additional specification of \key Beta_2, \key Beta_4, \key Theta and
  * \key Phi, which follow \iref{Moller:1993ed} and \iref{Schenke:2019ruo}. \n
  *
+ * \li \key E_Tot (double, optional, no default) Set the total
+ * energy (in GeV) per particle of the beam.  This key, if used, must
+ * be present for both \key Projectile and \key Target.
+ *
  * \li \key E_Kin (double, optional, no default) Set the kinetic
  * energy (in GeV) per particle of the beam.  This key, if used, must
  * be present for both \key Projectile and \key Target.
  *
  * \li \key P_Lab (double, optional, no default) Set the momentum (in
  * GeV/c) per particle of the beam.  This key, if used, must be
- * present for both \key Projectile and \key Target.
- 
- * \note Note on \key E_Kin and \key P_Lab.  If the beam specific
- * kinetic energy or momentum is set using either of these keys, then
- * it must be specified in the same way (not necessarily same value)
- * for both beams.  This is useful to simulate for example p-Pb
- * collisions at the LHC where the centre-of-mass system does not
- * correspond to the laboratory system.  E.g.,
+ * present for both \key Projectile and \key Target, and must be
+ * _positive_ for both beams.
+ *
+ * \note If the beam specific kinetic energy or momentum is set using
+ * either of these keys, then it must be specified in the same way
+ * (not necessarily same value) for both beams.  
+ * 
+ * This is useful to simulate for example p-Pb collisions at the LHC
+ * where the centre-of-mass system does not correspond to the
+ * laboratory system.  E.g.,
  *
  *\verbatim
 Modi:
@@ -151,12 +164,12 @@ Modi:
       Random_Reaction_Plane: True
       Range: [0, 8.5]
     Projectile:
-      E_Kin: 1580
+      E_Tot: 1580
       Particles:
         2212: 82
         2112: 126
     Target:
-      E_Kin: 4000
+      E_Tot: 4000
       Particles:
         2212: 1
         2112: 0
@@ -386,7 +399,22 @@ ColliderModus::ColliderModus(Configuration modus_config,
                mass_projec * mass_projec + mass_target * mass_target;
     energy_input++;
   }
-  /* Option 2: Kinetic energy per nucleon of the projectile nucleus
+  /* Option 2: Total energy per nucleon of the projectile nucleus
+   * (target at rest).  */
+  if (modus_cfg.has_value({"E_Tot"})) {
+    const double e_tot = modus_cfg.take({"E_Tot"});
+    if (e_kin < 0) {
+      throw ModusDefault::InvalidEnergy(
+          "Input Error: "
+          "E_Tot must be nonnegative.");
+    }
+    // Set the total nucleus-nucleus collision energy.
+    total_s_ = s_from_Etot(e_tot * projectile_->number_of_particles(),
+                           mass_projec, mass_target);
+    sqrt_s_NN_ = std::sqrt(s_from_Etot(e_kin, mass_a, mass_b));
+    energy_input++;
+  }
+  /* Option 3: Kinetic energy per nucleon of the projectile nucleus
    * (target at rest).  */
   if (modus_cfg.has_value({"E_Kin"})) {
     const double e_kin = modus_cfg.take({"E_Kin"});
@@ -401,7 +429,7 @@ ColliderModus::ColliderModus(Configuration modus_config,
     sqrt_s_NN_ = std::sqrt(s_from_Ekin(e_kin, mass_a, mass_b));
     energy_input++;
   }
-  // Option 3: Momentum of the projectile nucleus (target at rest).
+  // Option 4: Momentum of the projectile nucleus (target at rest).
   if (modus_cfg.has_value({"P_Lab"})) {
     const double p_lab = modus_cfg.take({"P_Lab"});
     if (p_lab < 0) {
@@ -415,7 +443,22 @@ ColliderModus::ColliderModus(Configuration modus_config,
     sqrt_s_NN_ = std::sqrt(s_from_plab(p_lab, mass_a, mass_b));
     energy_input++;
   }
-  // Option 4: Kinetic energy per nucleon of _each_ beam
+  // Option 5: Total energy per nucleon of _each_ beam
+  if (proj_cfg.has_value({"E_Tot"}) and targ_cfg.has_value({"E_Tot"})) {
+    const double e_tot_p = proj_cfg.take({"E_Tot"});
+    const double e_tot_t = targ_cfg.take({"E_tot"});
+    if (e_tot_p < 0 or e_tot_t < 0) {
+      throw ModusDefault::InvalidEnergy(
+          "Input Error: "
+          "E_Tot must be nonnegative.");
+    }
+    total_s_ = s_from_Etot(e_tot_p * projectile_->number_of_particles(),
+			   e_tot_t * target_    ->number_of_particles(),
+			   mass_projec, mass_target);
+    sqrt_s_NN_ = std::sqrt(s_from_Ekin(e_tot_p,e_tot_t,mass_a,mass_b));
+    energy_input++;
+  }
+  // Option 6: Kinetic energy per nucleon of _each_ beam
   if (proj_cfg.has_value({"E_Kin"}) and targ_cfg.has_value({"E_Kin"})) {
     const double e_kin_p = proj_cfg.take({"E_Kin"});
     const double e_kin_t = targ_cfg.take({"E_Kin"});
@@ -430,11 +473,11 @@ ColliderModus::ColliderModus(Configuration modus_config,
     sqrt_s_NN_ = std::sqrt(s_from_Ekin(e_kin_p,e_kin_t,mass_a,mass_b));
     energy_input++;
   }
-  // Option 5: Momentum per nucleon of _each_ beam
+  // Option 7: Momentum per nucleon of _each_ beam
   if (proj_cfg.has_value({"P_Lab"}) and targ_cfg.has_value({"P_Lab"})) {
     const double p_lab_p = proj_cfg.take({"P_Lab"});
     const double p_lab_t = targ_cfg.take({"P_Lab"});
-    if (p_lab_p < 0 or p_lab_t < 0) { // Really!?
+    if (p_lab_p < 0 or p_lab_t < 0) {
       throw ModusDefault::InvalidEnergy(
           "Input Error: "
           "P_Lab must be nonnegative.");

--- a/src/collidermodus.cc
+++ b/src/collidermodus.cc
@@ -403,7 +403,7 @@ ColliderModus::ColliderModus(Configuration modus_config,
    * (target at rest).  */
   if (modus_cfg.has_value({"E_Tot"})) {
     const double e_tot = modus_cfg.take({"E_Tot"});
-    if (e_kin < 0) {
+    if (e_tot < 0) {
       throw ModusDefault::InvalidEnergy(
           "Input Error: "
           "E_Tot must be nonnegative.");
@@ -411,7 +411,7 @@ ColliderModus::ColliderModus(Configuration modus_config,
     // Set the total nucleus-nucleus collision energy.
     total_s_ = s_from_Etot(e_tot * projectile_->number_of_particles(),
                            mass_projec, mass_target);
-    sqrt_s_NN_ = std::sqrt(s_from_Etot(e_kin, mass_a, mass_b));
+    sqrt_s_NN_ = std::sqrt(s_from_Etot(e_tot, mass_a, mass_b));
     energy_input++;
   }
   /* Option 3: Kinetic energy per nucleon of the projectile nucleus

--- a/src/include/smash/configuration.h
+++ b/src/include/smash/configuration.h
@@ -1044,17 +1044,15 @@ class Configuration {
    */
   explicit Configuration(const bf::path &path, const bf::path &filename);
 
-#ifdef BUILD_TESTS
   /**
-   * \mocking
-   * Unit tests can use this constructor to get a Configuration object from a
-   * built-in string.
-   * This function is only available to tests and should never be used/needed in
-   * actual SMASH code. The intention is to avoid creating a mock object for
-   * Configuration to test other classes of SMASH.
+   * Initialize configuration with a YAML formatted string.  This is
+   * useful in 3-rd party application where we may not be able or
+   * willing to read in external files. This constructor is also used
+   * in the test-suite.
+   * 
+   * \param[in] yaml YAML formatted configuration data.
    */
-  explicit Configuration(const char *yaml) : root_node_(YAML::Load(yaml)) {}
-#endif
+  explicit Configuration(const char *yaml) { merge_yaml(yaml); }
 
   /// If you want to copy this you're doing it wrong
   Configuration(const Configuration &) = default;

--- a/src/include/smash/experiment.h
+++ b/src/include/smash/experiment.h
@@ -233,6 +233,25 @@ class Experiment : public ExperimentBase {
    */
   Modus *modus() { return &modus_; }
 
+  /** Number of projectile participants */
+  int npart_projectile() const
+  {
+    int np = 0;
+    for (size_t i = 0; i < this->modus_.proj_N_number(); i++)
+      np += nucleon_has_interacted_[i] ? 1 : 0;
+    return np;
+  }
+  /** Number of projectile participants */
+  int npart_target() const
+  {
+    int nt = 0;
+    for (size_t i = this->modus_.proj_N_number(); 
+	 i < this->modus_
+	   .total_N_number(); i++)
+      nt += nucleon_has_interacted_[i] ? 1 : 0;
+    return nt;
+  }
+  bool has_interaction() const { return projectile_target_interact_; }
  private:
   /**
    * Perform the given action.
@@ -1470,7 +1489,10 @@ void Experiment<Modus>::initialize_new_event(int event_number) {
   }
 
   particles_.reset();
-
+  // make sure this is initialized
+  if (modus_.is_collider())
+    nucleon_has_interacted_.assign(modus_.total_N_number(),false);
+  
   // Sample particles according to the initial conditions
   double start_time = modus_.initial_conditions(&particles_, parameters_);
   /* For box modus make sure that particles are in the box. In principle, after

--- a/src/include/smash/experiment.h
+++ b/src/include/smash/experiment.h
@@ -251,7 +251,9 @@ class Experiment : public ExperimentBase {
       nt += nucleon_has_interacted_[i] ? 1 : 0;
     return nt;
   }
-  bool has_interaction() const { return projectile_target_interact_; }
+  /** Return true if any two beam particles interacted */
+  bool projectile_target_have_interacted() () const {
+    return projectile_target_interact_; }
  private:
   /**
    * Perform the given action.
@@ -1491,8 +1493,9 @@ void Experiment<Modus>::initialize_new_event(int event_number) {
 
   particles_.reset();
   // make sure this is initialized
-  if (modus_.is_collider())
+  if (modus_.is_collider()) {
     nucleon_has_interacted_.assign(modus_.total_N_number(),false);
+  }
   
   // Sample particles according to the initial conditions
   double start_time = modus_.initial_conditions(&particles_, parameters_);

--- a/src/include/smash/experiment.h
+++ b/src/include/smash/experiment.h
@@ -252,7 +252,7 @@ class Experiment : public ExperimentBase {
     return nt;
   }
   /** Return true if any two beam particles interacted */
-  bool projectile_target_have_interacted() () const {
+  bool projectile_target_have_interacted() const {
     return projectile_target_interact_; }
  private:
   /**

--- a/src/include/smash/kinematics.h
+++ b/src/include/smash/kinematics.h
@@ -211,7 +211,23 @@ inline double plab_from_s(double mandelstam_s, double m_projectile,
 inline double s_from_Ekin(double e_kin, double m_P, double m_T) {
   return m_P * m_P + m_T * m_T + 2 * m_T * (m_P + e_kin);
 }
-
+/** 
+ * Convert E_kin to Mandelstam-s for two beams with total energies and masses 
+ * (E,m) (E_kin gives per nucleon, E=E_kin*A) 
+ *
+ * \param[in] e_kin_p Kinetic energy of projectile [GeV]     
+ * \param[in] e_kin_t Kinetic energy of target [GeV]     
+ * \param[in] m_p     Mass of projectile [GeV]
+ * \param[in] m_t     Mass of target     [GeV]
+ * \return Mandelstam-s [GeV^2]
+ */
+inline double s_from_Ekin(double e_kin_p, double e_kin_t,
+			  double m_p,     double m_t)
+{
+  double pz_p = std::sqrt(e_kin_p * e_kin_p - m_p * m_p);
+  double pz_t = std::sqrt(e_kin_t * e_kin_t - m_t * m_t);
+  return std::pow(e_kin_p+e_kin_t,2)-pow(pz_p-pz_t,2);
+}
 /**
  * Convert p_lab to Mandelstam-s for a fixed-target setup,
  * with a projectile of mass m_P and momentum plab
@@ -223,6 +239,23 @@ inline double s_from_Ekin(double e_kin, double m_P, double m_T) {
  */
 inline double s_from_plab(double plab, double m_P, double m_T) {
   return m_P * m_P + m_T * m_T + 2 * m_T * std::sqrt(m_P * m_P + plab * plab);
+}
+/** 
+ * Convert P_lab to Mandelstam-s for two beams with total momenta and masses 
+ * (P,m) (P_lab gives per nucleon, P=P_lab*A) 
+ *
+ * \param[in] plab_p Kinetic energy of projectile [GeV]     
+ * \param[in] plab_t Kinetic energy of target [GeV]     
+ * \param[in] m_p    Mass of projectile [GeV]
+ * \param[in] m_t    Mass of target     [GeV]
+ * \return Mandelstam-s [GeV^2]
+ */
+inline double s_from_plab(double plab_p, double plab_t,
+			  double m_p,    double m_t)
+{
+  double e_p = std::sqrt(m_p * m_p + plab_p*plab_p);
+  double e_t = std::sqrt(m_t * m_t + plab_t*plab_t);
+  return std::pow(e_p+e_t,2)-pow(plab_p-plab_t,2);
 }
 
 }  // namespace smash

--- a/src/include/smash/kinematics.h
+++ b/src/include/smash/kinematics.h
@@ -224,9 +224,9 @@ inline double s_from_Etot(double e_tot, double m_P, double m_T) {
 inline double s_from_Etot(double e_tot_p, double e_tot_t,
 			  double m_p,     double m_t)
 {
-  double pz_p = std::sqrt(e_kin_p * e_kin_p - m_p * m_p);
-  double pz_t = std::sqrt(e_kin_t * e_kin_t - m_t * m_t);
-  return std::pow(e_kin_p+e_kin_t,2)-std::pow(pz_p-pz_t,2);
+  double pz_p = std::sqrt(e_tot_p * e_tot_p - m_p * m_p);
+  double pz_t = std::sqrt(e_tot_t * e_tot_t - m_t * m_t);
+  return std::pow(e_tot_p+e_tot_t,2)-std::pow(pz_p-pz_t,2);
 }
 /**
  * Convert E_kin to Mandelstam-s for a fixed-target setup,
@@ -282,7 +282,7 @@ inline double s_from_plab(double plab_p, double plab_t,
 {
   return s_from_Etot(std::sqrt(m_p * m_p + plab_p*plab_p),
 		     std::sqrt(m_t * m_t + plab_t*plab_t),
-		     plap_p, plab_t);
+		     plab_p, plab_t);
 }
 
 }  // namespace smash

--- a/src/include/smash/kinematics.h
+++ b/src/include/smash/kinematics.h
@@ -200,6 +200,35 @@ inline double plab_from_s(double mandelstam_s, double m_projectile,
 }
 
 /**
+ * Convert E_tot to Mandelstam-s for a fixed-target setup,
+ * with a projectile of mass m_P and a kinetic energy e_kin
+ * and a target of mass m_T at rest.
+ * \param[in] e_kin kinetic energy of the projectile in the lab frame [GeV]
+ * \param[in] m_P mass of the projectile [GeV]
+ * \param[in] m_T mass of the target [GeV]
+ * \return The Mandelstam variable s [GeV^2]
+ */
+inline double s_from_Etot(double e_tot, double m_P, double m_T) {
+  return m_P * m_P + m_T * m_T + 2 * m_T * e_tot;
+}
+/** 
+ * Convert E_tot to Mandelstam-s for two beams with total energies and
+ * masses (E,m)
+ *
+ * \param[in] e_tot_p Total energy of projectile [GeV]     
+ * \param[in] e_tot_t Total energy of target [GeV]     
+ * \param[in] m_p     Mass of projectile [GeV]
+ * \param[in] m_t     Mass of target     [GeV]
+ * \return Mandelstam-s [GeV^2]
+ */
+inline double s_from_Etot(double e_tot_p, double e_tot_t,
+			  double m_p,     double m_t)
+{
+  double pz_p = std::sqrt(e_kin_p * e_kin_p - m_p * m_p);
+  double pz_t = std::sqrt(e_kin_t * e_kin_t - m_t * m_t);
+  return std::pow(e_kin_p+e_kin_t,2)-std::pow(pz_p-pz_t,2);
+}
+/**
  * Convert E_kin to Mandelstam-s for a fixed-target setup,
  * with a projectile of mass m_P and a kinetic energy e_kin
  * and a target of mass m_T at rest.
@@ -209,11 +238,11 @@ inline double plab_from_s(double mandelstam_s, double m_projectile,
  * \return The Mandelstam variable s [GeV^2]
  */
 inline double s_from_Ekin(double e_kin, double m_P, double m_T) {
-  return m_P * m_P + m_T * m_T + 2 * m_T * (m_P + e_kin);
+  return s_from_Etot(e_kin+m_P, m_P, m_T);
 }
 /** 
- * Convert E_kin to Mandelstam-s for two beams with total energies and masses 
- * (E,m) (E_kin gives per nucleon, E=E_kin*A) 
+ * Convert E_kin=(E_tot-m) to Mandelstam-s for two beams with total
+ * energies and masses (E,m) 
  *
  * \param[in] e_kin_p Kinetic energy of projectile [GeV]     
  * \param[in] e_kin_t Kinetic energy of target [GeV]     
@@ -224,9 +253,7 @@ inline double s_from_Ekin(double e_kin, double m_P, double m_T) {
 inline double s_from_Ekin(double e_kin_p, double e_kin_t,
 			  double m_p,     double m_t)
 {
-  double pz_p = std::sqrt(e_kin_p * e_kin_p - m_p * m_p);
-  double pz_t = std::sqrt(e_kin_t * e_kin_t - m_t * m_t);
-  return std::pow(e_kin_p+e_kin_t,2)-pow(pz_p-pz_t,2);
+  return s_from_Etot(e_kin_p+m_t, e_kin_t+m_t,m_p,m_t);
 }
 /**
  * Convert p_lab to Mandelstam-s for a fixed-target setup,
@@ -253,9 +280,9 @@ inline double s_from_plab(double plab, double m_P, double m_T) {
 inline double s_from_plab(double plab_p, double plab_t,
 			  double m_p,    double m_t)
 {
-  double e_p = std::sqrt(m_p * m_p + plab_p*plab_p);
-  double e_t = std::sqrt(m_t * m_t + plab_t*plab_t);
-  return std::pow(e_p+e_t,2)-pow(plab_p-plab_t,2);
+  return s_from_Etot(std::sqrt(m_p * m_p + plab_p*plab_p),
+		     std::sqrt(m_t * m_t + plab_t*plab_t),
+		     plap_p, plab_t);
 }
 
 }  // namespace smash


### PR DESCRIPTION
- Allow specifying per-beam `E_Kin` or `P_Lab`.  This introduces the configuration keys

      ```
      Modi:
        Collider:
          Projectile:
            E_Kin: <Kinetic energy in GeV per particle of projectile beam>
          Target:
            E_Kin: <Kinetic energy in GeV per particle of target beam>
      ```

  or the same but with `P_Lab`.  This is to allow simulation of for example p-Pb collisions
  at the LHC:

      ```
      Modi:
        Collider:
        Calculation_Frame: center of velocity
        Impact:
           Random_Reaction_Plane: True
           Range: [0, 15]
        Projectile:
          E_Kin: 1580
          Particles:
            2212: 82
            2112: 126
        Target:
          E_Kin: 4000
          Particles:
            2212: 1
            2112: 0
      ```

  At the LHC, the beams share magnet systems, meaning that the energy per _charge_ is always the same for
  both beams.  That means that for, for example, p-Pb at 5.02TeV _both_ beams had $`E_{\mathrm{kin}}/q=4\,\mathrm{TeV}`$
  resulting in the above kinetic energies per nucleon.   Clearly, this means that the centre-of-mass rapidity
  is _not_ zero ($`y_{\mathrm{CM}}\approx -0.465`$).   SMASH will continue to calculate in the CM system,
  and so the user has to be careful to boost the final state particles to the lab system.

  This changes thins in

  - `src/collidermodus.cc` - added documentation and handling of new keys
  - `src/include/smash/kinematics.hh` - added overload of `s_from_Ekin` and `s_from_plab`

- Allow construction of `smash::Configuration` from a YAML string.  This allows a user to make
  a `smash::Configuration` object from a YAML string directly.  This is useful in 3rd-party applications
  where it may not be possible or desireable to read external files.  This was already available when `BUILD_TEST`
  was true.  However, it has general applicability.

  This changes

  - `src/include/smash/Configuration.h` - Remove preprocessor guard `#ifdef BUILD_TEST` and add docs

- Give access to number of projectile and target participants and query if interactions occured

  Applications can query `smash::Experument<T>` for the number of participants in each beam via member
  functions `npart_projectile` and `npart_target`.  These sum up the respective fields of `smash::Experiment<T>::nucleon_has_interacted_`

  To this end (as well as to prevent SIGSEGV from elsewhere), it is _crucial_ that `smash::Experiment<T>::nucleon_has_interacted_` is initialised.
  Normally that initialisation happens in `smash::Experiment<T>::run` but that member function is only appropriate for internal use of SMASH - not for 3rd-party use.  The member is therefore initialized in `smash::Experiment<T>::initialize_new_event` (at no cost)

  The changes also gives read-only access to the internal member `smash::Experiment<T>::projectile_target_interact_` via
  the member function `smash::Experiment<T>::has_interaction`.  This allows third party applications to query
  the experiment object if the current event actually contains interactions.   For example, suppose you hare simulating
  min-bias A-A collisions by sampling the impact parameter over $`0-b_{\mathrm{max}}`$.  Depending on the maximum impact
  paramter sampled, SMASH may produce events that contain no interactions.  however, for our study we would like to
  have $`N`$ min-bias events, so we need to know if we should actually take any given event

      ```
      for (int evno = 0; evno < nev; evno++) {
         do {
           experiment->initialize_new_event();
           experiment->run_time_evolution();
           experiment->do_final_decays();
         } while (!experiment->has_interaction());

         // Do something with the data for this event
      }
      ```

  without this possibility, one ends up with a lot of empty events.

  BTW, another option for this that perhaps fits better with the design of SMASH would be to allow
  user defined `smash::Action` objects added to the experiment.  For example, one could define
  a class

    ```
    struct smash::Rivet : public smash::OutputInterface
    {
      Rivet(...) { ... } // Set-up Rivet
      void at_eventstart(const Particles& particles,
                         const int event_number,
                         const EventInfo& info)
      {
        event_.reset();

        // Generate IP and add incoming beams
        ip_ = std::make_shared<HepMC3::GenVertex>();
        ip_.add_particle_in(projectile);
        ip_.add_particle_in(target);
        event_.add_vertex(ip_);
      }
      void at_eventend(const Particles& particles,
                       const int event_number,
                       const EventInfo& info)
       {
         // Add final state particles to ip_

         if (!rivet_init_) {
           // Initialize Rivet on first event
           rivet_->init(event_);
           rivet_init = true;
         }

         rivet_->analyze(_event);
       }
       ~Rivet()
       {
         rivet_->write(...);
       }
      };
      ```

  Currently, you only allow for built-in actions.

  - This changes `src/include/smash/experiment.h` - added member functions and init of member.