### PR TITLE
Script to enable GitHub action and other minor bugfixes/improvements

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,7 +67,7 @@ jobs:
             sudo apt-get install ${{ matrix.packages_to_add }} -y
         fi
         # we download and install Pythia
-        wget http://home.thep.lu.se/~torbjorn/pythia8/pythia8303.tgz && tar xf pythia8303.tgz && rm pythia8303.tgz && cd pythia8303
+        wget https://pythia.org/download/pythia83/pythia8303.tgz && tar xf pythia8303.tgz && rm pythia8303.tgz && cd pythia8303
         ./configure --cxx-common='-std=c++11 -march=native -mfpmath=sse -O3 -fPIC' && make -j$(nproc) && cd ..
         # we download and unpack clang
         if [ $OS_NAME == "macos-latest" ]; then curl -# -o clang6_0_0.tar.xz https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz;

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,8 +42,8 @@ jobs:
           cxx_compiler_to_use: "clang++"
         # 5th matrix element, default compiler in Goethe cluster       
         - os: ubuntu-16.04
-          # this time we do not include boost and gsl, we compile them later by ourselves
-          packages_to_add: "g++-4.8"
+          # this time we do not include boost, we compile it later by ourselves
+          packages_to_add: "g++-4.8 libgsl-dev"
           c_compiler_to_use: "gcc-4.8"
           cxx_compiler_to_use: "g++-4.8"
     steps:   
@@ -73,12 +73,10 @@ jobs:
         if [ $OS_NAME == "macos-latest" ]; then curl -# -o clang6_0_0.tar.xz https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz;
         else curl -# -o clang6_0_0.tar.xz https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi &&
         mkdir clang6_0_0 && tar -xf clang6_0_0.tar.xz -C clang6_0_0 --strip-components=1
-        # if we use gcc-4.8 we download and build also boost and gsl
+        # if we use gcc-4.8 we download and build also boost
         if [ $CXX == "g++-4.8" ]; then
-            curl https://deac-fra.dl.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.gz -o boost_1_63_0.tar.gz --silent && tar -xf boost_1_63_0.tar.gz
-            cd boost_1_63_0 && ./bootstrap.sh --with-libraries=filesystem,system && ./b2 toolset=gcc-4.8 && export BOOST_DIR=$PWD && cd ..
-            wget https://ftp.wayne.edu/gnu/gsl/gsl-2.6.tar.gz && tar xf gsl-2.6.tar.gz && export GSL=$PWD && ./configure --prefix $GSL && make -j$(nproc) &&
-            make install && cd ..
+            curl https://deac-fra.dl.sourceforge.net/project/boost/boost/1.75.0/boost_1_75_0.tar.gz -o boost_1_75_0.tar.gz --silent && tar -xf boost_1_75_0.tar.gz
+            cd boost_1_75_0 && ./bootstrap.sh --with-libraries=filesystem,system && ./b2 toolset=gcc-4.8 && export BOOST_DIR=$PWD && cd ..            
         fi        
         # we get eigen
         wget http://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.gz && tar -xf eigen-3.3.9.tar.gz -C $HOME
@@ -89,7 +87,7 @@ jobs:
         cd $SMASH_ROOT && mkdir build && cd build
         # if we use gcc-4.8 we use our self built boost
         if [ $CXX == "g++-4.8" ]; then
-            cmake .. -DPythia_CONFIG_EXECUTABLE=$SMASH_ROOT/pythia8303/bin/pythia8-config -DBOOST_ROOT=$BOOST_DIR -DCMAKE_INSTALL_PREFIX=$HOME/eigen-3.3.9/ -DGSL_ROOT_DIR=$GSL
+            cmake .. -DPythia_CONFIG_EXECUTABLE=$SMASH_ROOT/pythia8303/bin/pythia8-config -DBOOST_ROOT=$BOOST_DIR -DCMAKE_INSTALL_PREFIX=$HOME/eigen-3.3.9/ 
         else
             cmake .. -DPythia_CONFIG_EXECUTABLE=$SMASH_ROOT/pythia8303/bin/pythia8-config -DCMAKE_INSTALL_PREFIX=$HOME/eigen-3.3.9/
         fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,8 @@ jobs:
     # the OS to be used for the test is taken from the current matrix element
     runs-on: ${{ matrix.os }}
     strategy:
+      # we want to avoid to stop all the tests the first time that one of them gets an error 
+      fail-fast: false
       matrix: 
         include:
         #here we set up the various matrix elements
@@ -38,18 +40,17 @@ jobs:
           packages_to_add: "boost gsl"
           c_compiler_to_use: "clang"
           cxx_compiler_to_use: "clang++"
-        # th matrix element, default compiler in Goethe cluster       
-        #- os: ubuntu-16.04
-        #  packages_to_add: "libboost-all-dev g++-4.8 libgsl-dev"
-        #  c_compiler_to_use: "gcc-4.8"
-        #  cxx_compiler_to_use: "g++-4.8"
+        # 5th matrix element, default compiler in Goethe cluster       
+        - os: ubuntu-16.04
+          # this time we do not include boost and gsl, we compile them later by ourselves
+          packages_to_add: "g++-4.8"
+          c_compiler_to_use: "gcc-4.8"
+          cxx_compiler_to_use: "g++-4.8"
     steps:   
     # this is an action provided by GitHub to checkout the repository
     - uses: actions/checkout@v2
     # we set the name of the step, collecting all the tests in just one step
-    - name: code_check
-      # uncomment the following line (and align with "env" below) to avoid to stop all the tests as soon as one of them gets an error 
-      # continue-on-error: true
+    - name: code_check     
     # we set some environment variables for the specific OS version
       env:
         CC: ${{ matrix.c_compiler_to_use }}
@@ -72,6 +73,13 @@ jobs:
         if [ $OS_NAME == "macos-latest" ]; then curl -# -o clang6_0_0.tar.xz https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz;
         else curl -# -o clang6_0_0.tar.xz https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi &&
         mkdir clang6_0_0 && tar -xf clang6_0_0.tar.xz -C clang6_0_0 --strip-components=1
+        # if we use gcc-4.8 we download and build also boost and gsl
+        if [ $CXX == "g++-4.8" ]; then
+            curl https://deac-fra.dl.sourceforge.net/project/boost/boost/1.63.0/boost_1_63_0.tar.gz -o boost_1_63_0.tar.gz --silent && tar -xf boost_1_63_0.tar.gz
+            cd boost_1_63_0 && ./bootstrap.sh --with-libraries=filesystem,system && ./b2 toolset=gcc-4.8 && export BOOST_DIR=$PWD && cd ..
+            wget https://ftp.wayne.edu/gnu/gsl/gsl-2.6.tar.gz && tar xf gsl-2.6.tar.gz && export GSL=$PWD && ./configure --prefix $GSL && make -j$(nproc) &&
+            make install && cd ..
+        fi        
         # we get eigen
         wget http://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.gz && tar -xf eigen-3.3.9.tar.gz -C $HOME
         # we get cpplint
@@ -79,7 +87,12 @@ jobs:
         export PATH=$HOME/bin:$PATH
         # now we build SMASH
         cd $SMASH_ROOT && mkdir build && cd build
-        cmake .. -DPythia_CONFIG_EXECUTABLE=$SMASH_ROOT/pythia8303/bin/pythia8-config -DCMAKE_INSTALL_PREFIX=$HOME/eigen-3.3.9/
+        # if we use gcc-4.8 we use our self built boost
+        if [ $CXX == "g++-4.8" ]; then
+            cmake .. -DPythia_CONFIG_EXECUTABLE=$SMASH_ROOT/pythia8303/bin/pythia8-config -DBOOST_ROOT=$BOOST_DIR -DCMAKE_INSTALL_PREFIX=$HOME/eigen-3.3.9/ -DGSL_ROOT_DIR=$GSL
+        else
+            cmake .. -DPythia_CONFIG_EXECUTABLE=$SMASH_ROOT/pythia8303/bin/pythia8-config -DCMAKE_INSTALL_PREFIX=$HOME/eigen-3.3.9/
+        fi
         make -j$(nproc)
         # we check the building of the documentation for a specific case
         if [ $OS_NAME == ubuntu-18.04 ]; then make undocumented && make undocumented_test; fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,89 @@
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check_pull:
+    # we use jobs in a matrix.
+    # the OS to be used for the test is taken from the current matrix element
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: 
+        include:
+        #here we set up the various matrix elements
+        #the entries in each matrix element are just variables, not keywords, with (hopefully) self-explaining names
+        # 1st matrix element, default compiler at FIAS
+        - os: ubuntu-18.04
+          packages_to_add: "libboost-all-dev g++-5 doxygen-latex graphviz libgsl-dev"
+          c_compiler_to_use: "gcc-5"
+          cxx_compiler_to_use: "g++-5"
+        # 2nd matrix element, recent LTS Ubuntu distribution with gcc
+        - os: ubuntu-20.04
+          packages_to_add: "libboost-all-dev doxygen-latex graphviz libgsl-dev"
+          c_compiler_to_use: "gcc"
+          cxx_compiler_to_use: "g++"
+        # 3rd matrix element, recent LTS Ubuntu distribution with clang
+        - os: ubuntu-20.04
+          packages_to_add: "libboost-all-dev libgsl-dev"
+          c_compiler_to_use: "clang"
+          cxx_compiler_to_use: "clang++"
+        # 4th matrix element, osx 10.15 with clang
+        - os: macos-latest
+          packages_to_add: "boost gsl"
+          c_compiler_to_use: "clang"
+          cxx_compiler_to_use: "clang++"
+        # th matrix element, default compiler in Goethe cluster       
+        #- os: ubuntu-16.04
+        #  packages_to_add: "libboost-all-dev g++-4.8 libgsl-dev"
+        #  c_compiler_to_use: "gcc-4.8"
+        #  cxx_compiler_to_use: "g++-4.8"
+    steps:   
+    # this is an action provided by GitHub to checkout the repository
+    - uses: actions/checkout@v2
+    # we set the name of the step, collecting all the tests in just one step
+    - name: code_check
+      # uncomment the following line (and align with "env" below) to avoid to stop all the tests as soon as one of them gets an error 
+      # continue-on-error: true
+    # we set some environment variables for the specific OS version
+      env:
+        CC: ${{ matrix.c_compiler_to_use }}
+        CXX: ${{ matrix.cxx_compiler_to_use }}
+        OS_NAME: ${{ matrix.os }}
+      # we run the step. We recall that in YAML the pipe symbol "|" means that the follwing lines, including newlines, are interpreted literally
+      run: |
+        # we set the smash root directory
+        export SMASH_ROOT=$PWD        
+        # we install the missing packages
+        if [ $OS_NAME == "macos-latest" ]; then
+            brew install ${{ matrix.packages_to_add }}
+        else
+            sudo apt-get install ${{ matrix.packages_to_add }} -y
+        fi
+        # we download and install Pythia
+        wget http://home.thep.lu.se/~torbjorn/pythia8/pythia8303.tgz && tar xf pythia8303.tgz && rm pythia8303.tgz && cd pythia8303
+        ./configure --cxx-common='-std=c++11 -march=native -mfpmath=sse -O3 -fPIC' && make -j$(nproc) && cd ..
+        # we download and unpack clang
+        if [ $OS_NAME == "macos-latest" ]; then curl -# -o clang6_0_0.tar.xz https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz;
+        else curl -# -o clang6_0_0.tar.xz https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-14.04.tar.xz; fi &&
+        mkdir clang6_0_0 && tar -xf clang6_0_0.tar.xz -C clang6_0_0 --strip-components=1
+        # we get eigen
+        wget http://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.gz && tar -xf eigen-3.3.9.tar.gz -C $HOME
+        # we get cpplint
+        wget https://raw.githubusercontent.com/cpplint/cpplint/develop/cpplint.py && chmod +x cpplint.py && mkdir -p $HOME/bin && mv cpplint.py $HOME/bin
+        export PATH=$HOME/bin:$PATH
+        # now we build SMASH
+        cd $SMASH_ROOT && mkdir build && cd build
+        cmake .. -DPythia_CONFIG_EXECUTABLE=$SMASH_ROOT/pythia8303/bin/pythia8-config -DCMAKE_INSTALL_PREFIX=$HOME/eigen-3.3.9/
+        make -j$(nproc)
+        # we check the building of the documentation for a specific case
+        if [ $OS_NAME == ubuntu-18.04 ]; then make undocumented && make undocumented_test; fi
+        # we check the correct formatting of the code with clang
+        PATH=$SMASH_ROOT/clang6_0_0/bin/:$PATH ./../bin/clang-format-helper.bash -t
+        # we run the tests
+        CTEST_OUTPUT_ON_FAILURE=1 ctest -j$(nproc)

--- a/.gitignore
+++ b/.gitignore
@@ -14,11 +14,6 @@ build*
 *.orig
 *.rej
 .DS_Store
-3rdparty/pythia8215/lib
-3rdparty/pythia8215/tmp
-3rdparty/pythia8215/share
-3rdparty/pythia8215/Makefile.inc
-3rdparty/pythia8215/examples/Makefile.inc
 .vscode
 
 # Convenience directory for your own files that should not be tracked

--- a/bin/clang-format-helper.bash
+++ b/bin/clang-format-helper.bash
@@ -47,10 +47,19 @@ case $1 in
       ;;
     -t | --test )
       echo "Testing that clang-format does not change the source code in the working directory ..."
-      if diff <(cat $FILES_TO_FORMAT) <(clang-format $FILES_TO_FORMAT) > /dev/null; then
-          echo "PASS: No changes to source code by clang-format."
-      else
+      check_flag=0
+      for file_under_examination in $FILES_TO_FORMAT; do
+	  diff <(cat $file_under_examination) <(clang-format $file_under_examination) > /dev/null;
+          if [ $? -ne 0 ]; then
+              echo "File $file_under_examination not properly formatted. Comparison with a properly formatted file:";
+	      diff <(cat $file_under_examination) <(clang-format $file_under_examination);
+	      check_flag=1;
+	  fi
+      done
+      if [ $check_flag -eq 1 ]; then
           fail "Clang-format was not properly run on latest commit."
+      else
+          echo "PASS: No changes to source code by clang-format."
       fi
       ;;
     * )

--- a/src/include/smash/cxx14compat.h
+++ b/src/include/smash/cxx14compat.h
@@ -27,7 +27,7 @@ inline std::unique_ptr<T> make_unique(Args &&... args) {
   return std::unique_ptr<T>{new T{std::forward<Args>(args)...}};
 }
 #else
-  using std::make_unique;
+using std::make_unique;
 #endif
 }  // namespace smash
 


### PR DESCRIPTION
The most relevant change is the addition of:
.github/workflows/tests.yaml
which activates the GitHub Actions upon pushing to master.

I modified: src/include/smash/cxx14compat.h
to fix the small issue detected by clang when running the tests.

I noticed that in .gitignore there are references to pythia 8.215, which is not used anymore, so I propose to cancel these lines.

I also propose to modify:  bin/clang-format-helper.bash
to identify the not correctly formatted files and provide some details about what should be changed.