### PR TITLE
Fix folder for Cuba dependency in FindSMASH.cmake

### DIFF
--- a/cmake/FindSMASH.cmake
+++ b/cmake/FindSMASH.cmake
@@ -19,7 +19,7 @@ find_package(Pythia 8.303 EXACT REQUIRED)
 set(SMASH_LIBRARIES ${GSL_LIBRARY} ${GSL_CBLAS_LIBRARY} ${Boost_LIBRARIES} ${Pythia_LIBRARIES} -ldl)
 
 set(SMASH_INCLUDE_DIR
-   $ENV{SMASH_DIR}/3rdparty/Cuba-4.2
+   $ENV{SMASH_DIR}/3rdparty/Cuba-4.2.1
    $ENV{SMASH_DIR}/3rdparty/einhard
    $ENV{SMASH_DIR}/3rdparty/yaml-cpp-0.6.2/include
    $ENV{SMASH_DIR}/build/src/include
@@ -34,7 +34,7 @@ message(STATUS "SMASH includes found in ${SMASH_INCLUDE_DIR}")
 find_library(SMASH_LIBRARY        NAMES smash     PATHS $ENV{SMASH_DIR}/build/src)
 find_library(EINHARD_LIBRARY      NAMES einhard   PATHS $ENV{SMASH_DIR}/build/3rdparty/einhard)
 find_library(CPPYAML_LIBRARY      NAMES yaml-cpp  PATHS $ENV{SMASH_DIR}/build/3rdparty/yaml-cpp-0.6.2)
-find_library(INTEGRATION_LIBRARY  NAMES cuhre     PATHS $ENV{SMASH_DIR}/build/3rdparty/Cuba-4.2/src/cuhre)
+find_library(INTEGRATION_LIBRARY  NAMES cuhre     PATHS $ENV{SMASH_DIR}/build/3rdparty/Cuba-4.2.1/src/cuhre)
 set(SMASH_LIBRARIES ${SMASH_LIBRARIES}
    ${EINHARD_LIBRARY}
    ${CPPYAML_LIBRARY}


### PR DESCRIPTION
the 3rd party library Cuba seems to be updated (4.2 -> 4.2.1) but the searched directories in FindSMASH.cmake do not match. Therefore the HadronSampler can not compile.