### PR TITLE
Put unformed particles on the grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ The major categories to group changes in this log are:
 
 Also possible, but for this project less relevant, is `Deprecated` for soon-to-be removed features.
 
+##[SMASH-2.1.3](https://github.com/smash-transport/smash/compare/SMASH-2.1.2...SMASH-2.1.3)
+Date: 2022-02-15
+
+### Changed
+* Include unformed particles in initial conditions output
+
+
 ## [SMASH-2.1.2](https://github.com/smash-transport/smash/compare/SMASH-2.1.1...SMASH-2.1.2)
 Date: 2022-02-04
 

--- a/src/include/smash/boxmodus.h
+++ b/src/include/smash/boxmodus.h
@@ -94,6 +94,7 @@ class BoxModus : public ModusDefault {
   Grid<GridOptions::PeriodicBoundaries> create_grid(
       const Particles &particles, double min_cell_length,
       double timestep_duration, CollisionCriterion crit,
+      const bool include_unformed_particles,
       CellSizeStrategy strategy = CellSizeStrategy::Optimal) const {
     CellNumberLimitation limit = CellNumberLimitation::ParticleNumber;
     if (crit == CollisionCriterion::Stochastic) {
@@ -104,6 +105,7 @@ class BoxModus : public ModusDefault {
             min_cell_length,
             timestep_duration,
             limit,
+            include_unformed_particles,
             strategy};
   }
 

--- a/src/include/smash/experiment.h
+++ b/src/include/smash/experiment.h
@@ -2217,11 +2217,16 @@ void Experiment<Modus>::run_time_evolution() {
         const double min_cell_length = compute_min_cell_length(dt);
         logg[LExperiment].debug("Creating grid with minimal cell length ",
                                 min_cell_length);
+        /* For the hyper-surface-crossing actions also unformed particles are
+         * searched and therefore needed on the grid. */
+        const bool include_unformed_particles = IC_output_switch_;
         const auto &grid =
             use_grid_ ? modus_.create_grid(ensembles_[i_ens], min_cell_length,
-                                           dt, parameters_.coll_crit)
+                                           dt, parameters_.coll_crit,
+                                           include_unformed_particles)
                       : modus_.create_grid(ensembles_[i_ens], min_cell_length,
                                            dt, parameters_.coll_crit,
+                                           include_unformed_particles,
                                            CellSizeStrategy::Largest);
 
         const double gcell_vol = grid.cell_volume();

--- a/src/include/smash/grid.h
+++ b/src/include/smash/grid.h
@@ -106,16 +106,20 @@ class Grid : public GridBase {
    * formation times treatment: if particle is fully or partially formed before
    * the end of the timestep, it has to be on the grid.
    * \param[in] limit Limitation of cell number
+   * \param[in] include_unformed_particles include unformed particles from
+                                              the grid (worsens runtime)
    * \param[in] strategy The strategy for determining the cell size
    */
   Grid(const Particles &particles, double min_cell_length,
        double timestep_duration, CellNumberLimitation limit,
+       const bool include_unformed_particles = false,
        CellSizeStrategy strategy = CellSizeStrategy::Optimal)
       : Grid{find_min_and_length(particles),
              std::move(particles),
              min_cell_length,
              timestep_duration,
              limit,
+             include_unformed_particles,
              strategy} {}
 
   /**
@@ -129,6 +133,8 @@ class Grid : public GridBase {
    * \param[in] min_cell_length The minimal length a cell must have.
    * \param[in] timestep_duration duration of the timestep in fm/c
    * \param[in] limit Limitation of cell number
+   * \param[in] include_unformed_particles include unformed particles from
+                                              the grid (worsens runtime)
    * \param[in] strategy The strategy for determining the cell size
    * \throws runtime_error if your box length is smaller than the grid length.
    */
@@ -136,6 +142,7 @@ class Grid : public GridBase {
            &min_and_length,
        const Particles &particles, double min_cell_length,
        double timestep_duration, CellNumberLimitation limit,
+       const bool include_unformed_particles = false,
        CellSizeStrategy strategy = CellSizeStrategy::Optimal);
 
   /**

--- a/src/include/smash/listmodus.h
+++ b/src/include/smash/listmodus.h
@@ -292,6 +292,7 @@ class ListBoxModus : public ListModus {
   Grid<GridOptions::PeriodicBoundaries> create_grid(
       const Particles &particles, double min_cell_length,
       double timestep_duration, CollisionCriterion crit,
+      const bool include_unformed_particles,
       CellSizeStrategy strategy = CellSizeStrategy::Optimal) const {
     CellNumberLimitation limit = CellNumberLimitation::ParticleNumber;
     if (crit == CollisionCriterion::Stochastic) {
@@ -302,6 +303,7 @@ class ListBoxModus : public ListModus {
             min_cell_length,
             timestep_duration,
             limit,
+            include_unformed_particles,
             strategy};
   }
 

--- a/src/include/smash/modusdefault.h
+++ b/src/include/smash/modusdefault.h
@@ -113,6 +113,9 @@ class ModusDefault {
    * formation times treatment: if particle is fully or partially formed before
    * the end of the timestep, it has to be on the grid.
    * \param[in] crit Collision criterion (decides if cell number can be limited)
+   * \param[in] include_unformed_particles include unformed particles from
+                                           the grid (worsens runtime, necessary
+                                           for IC output)
    * \param[in] strategy The strategy to determine the cell size \return the
    * Grid object
    *
@@ -121,12 +124,18 @@ class ModusDefault {
   Grid<GridOptions::Normal> create_grid(
       const Particles& particles, double min_cell_length,
       double timestep_duration, CollisionCriterion crit,
+      const bool include_unformed_particles,
       CellSizeStrategy strategy = CellSizeStrategy::Optimal) const {
     CellNumberLimitation limit = CellNumberLimitation::ParticleNumber;
     if (crit == CollisionCriterion::Stochastic) {
       limit = CellNumberLimitation::None;
     }
-    return {particles, min_cell_length, timestep_duration, limit, strategy};
+    return {particles,
+            min_cell_length,
+            timestep_duration,
+            limit,
+            include_unformed_particles,
+            strategy};
   }
 
   /**


### PR DESCRIPTION
When employing SMASH to extract initial conditions for hydrodynamics, 
unformed particles are needed on the grid, else their 
HypersurfaceCrossingActions cannot be found. Yet, they should contribute 
to the initial hydrodynamical densities. For this a boolean is 
introduced which allows placing particles on the grid if the ICOutput is 
enabled, but else neglects them to improve performance.