### PR TITLE
[Bugfix] Properly reset projectile_target_interact_-vector at event start

### DIFF
--- a/src/include/smash/experiment.h
+++ b/src/include/smash/experiment.h
@@ -1924,7 +1924,7 @@ void Experiment<Modus>::initialize_new_event() {
   previous_interactions_total_ = 0;
   discarded_interactions_total_ = 0;
   total_pauli_blocked_ = 0;
-  projectile_target_interact_.resize(parameters_.n_ensembles, false);
+  projectile_target_interact_.assign(parameters_.n_ensembles, false);
   total_hypersurface_crossing_actions_ = 0;
   total_energy_removed_ = 0.0;
   // Print output headers


### PR DESCRIPTION
Hello,

today I discovered a small bug in SMASH which is fixed by this pull request.

I discovered the bug when I was trying to calcualte minimum bias events. Therefore I set the "Only_Final" option to "IfNotEmpty" to omit events without interactions from the output. However, I realized that this only worked until the first event with interactions was calcualted and after that one, all event were written to the output no matter whether they contained interactions or not. After looking through the code, I figured out that the reason therefore was that the "projectile_target_interact_"-vector containing the information whether an interaction took place was not properly reset at the beginning of a new event as only new elements of that vector were set to "false" leaving all of its other contents unchained. Thus after the first event with an interaction occurred, the value "true" remained for all further events.

This small bugfix assures that the entire vector is reset at the beginning of a new event.

All the best,
Simon