### PR TITLE
Fix radial velocity in sphere mode and actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,13 +44,6 @@ jobs:
           packages_to_add: "boost gsl"
           c_compiler_to_use: "clang"
           cxx_compiler_to_use: "clang++"
-        # 5th matrix element, default compiler in Goethe cluster
-        - os: ubuntu-18.04
-          # this time we do not include boost, we compile it later by ourselves
-          site: "goethe"
-          packages_to_add: "g++-4.8 libgsl-dev"
-          c_compiler_to_use: "gcc-4.8"
-          cxx_compiler_to_use: "g++-4.8"
     steps:
     # this is an action provided by GitHub to checkout the repository
     - uses: actions/checkout@v2
@@ -81,11 +74,6 @@ jobs:
         if [ $SITE == "mac" ]; then curl -# -o clang6_0_0.tar.xz https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-apple-darwin.tar.xz;
         else curl -# -o clang6_0_0.tar.xz https://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz; fi &&
         mkdir clang6_0_0 && tar -xf clang6_0_0.tar.xz -C clang6_0_0 --strip-components=1
-        # if we use gcc-4.8 we download and build also boost
-        if [ $CXX == "g++-4.8" ]; then
-            curl https://deac-fra.dl.sourceforge.net/project/boost/boost/1.75.0/boost_1_75_0.tar.gz -o boost_1_75_0.tar.gz --silent && tar -xf boost_1_75_0.tar.gz
-            cd boost_1_75_0 && ./bootstrap.sh --with-libraries=filesystem,system && ./b2 toolset=gcc-4.8 && export BOOST_DIR=$PWD && cd ..
-        fi
         # we get eigen
         wget http://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.tar.gz && tar -xf eigen-3.4.0.tar.gz -C $HOME
         # we get cpplint
@@ -93,12 +81,7 @@ jobs:
         export PATH=$HOME/bin:$PATH
         # now we build SMASH
         cd $SMASH_ROOT && mkdir build && cd build
-        # if we use gcc-4.8 we use our self built boost
-        if [ $CXX == "g++-4.8" ]; then
-            cmake .. -DPythia_CONFIG_EXECUTABLE=$SMASH_ROOT/pythia8307/bin/pythia8-config -DBOOST_ROOT=$BOOST_DIR -DCMAKE_INSTALL_PREFIX=$HOME/eigen-3.4.0/
-        else
-            cmake .. -DPythia_CONFIG_EXECUTABLE=$SMASH_ROOT/pythia8307/bin/pythia8-config -DCMAKE_INSTALL_PREFIX=$HOME/eigen-3.4.0/
-        fi
+        cmake .. -DPythia_CONFIG_EXECUTABLE=$SMASH_ROOT/pythia8307/bin/pythia8-config -DCMAKE_INSTALL_PREFIX=$HOME/eigen-3.4.0/
         make -j$(nproc)
         # we check the building of the documentation for a specific case
         if [ $SITE == "fias" ]; then make undocumented_test && make user; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ The major categories to group changes in this log are:
 Also possible, but for this project less relevant, is `Deprecated` for soon-to-be removed features.
 
 
+## SMASH-2.2.1
+Date: 2022-05-18
+
+### Fixed
+* Properly boost in radial direction in sphere mode
+
+[Link to diff from previous version](https://github.com/smash-transport/smash/compare/SMASH-2.2...SMASH-2.2.1)
+
+
 ## SMASH-2.2
 Date: 2022-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Date: 2022-05-10
 
 ### Removed
 * A possibly available system installation of YAML library is not considered anymore
+* The singularity container definition has been dropped, since a singularity container can be obtained from the shipped docker
 
 [Link to diff from previous version](https://github.com/smash-transport/smash/compare/SMASH-2.1.4...SMASH-2.2)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,7 @@
 cmake_minimum_required(VERSION 3.9)
 
 # The name, version and language of our project
-project(SMASH VERSION 2.2 LANGUAGES CXX)
-set(SMASH_VERSION "${SMASH_VERSION}-next")
+project(SMASH VERSION 2.2.1 LANGUAGES CXX)
 
 # Fail if cmake is called in the source directory
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ cmake_minimum_required(VERSION 3.9)
 
 # The name, version and language of our project
 project(SMASH VERSION 2.2 LANGUAGES CXX)
+set(SMASH_VERSION "${SMASH_VERSION}-next")
 
 # Fail if cmake is called in the source directory
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ at elfner@itp.uni-frankfurt.de.
 
 SMASH is known to compile and work with one of these compilers (which have the
 required C++11 features):
-- gcc >= 4.8
+- gcc >= 5.0
 - clang >= 3.2
 
 It requires the following tools & libraries:

--- a/src/spheremodus.cc
+++ b/src/spheremodus.cc
@@ -340,7 +340,8 @@ double SphereModus::initial_conditions(Particles *particles,
     for (ParticleData &data : *particles) {
       double particle_radius = std::sqrt(data.position().sqr3());
       auto e_r = data.position().threevec() / particle_radius;
-      auto radial_velocity = radial_velocity_ * e_r * particle_radius / radius_;
+      auto radial_velocity =
+          -1.0 * radial_velocity_ * e_r * particle_radius / radius_;
       data.set_4momentum(data.momentum().lorentz_boost(radial_velocity));
       momentum_total += data.momentum();
     }


### PR DESCRIPTION
The idea of the feature `Add_Radial_Velocity` is to add a velocity of the form `u_r = u_0 * r / R` to each particle in radial direction in order to mimic additional expansion like in a heavy-ion collision.

The general implementation itself works fine however the boost was performed in the wrong direction. With the current implementation, the resulting average velocity points into the sphere instead of outwards because the boost is taken along the positive radial direction. The fix to this problem is simply a sign change of the boosting velocity in order to boost the particles in an outwards direction.

This PR will be tagged `SMASH-2.2.1` and, therefore, the CHANGELOG entry as well as the version bump.

The minimum version of `gcc` is now 5.0 in order to be able to compile tests as well (version 4.8 of the compiler had troubles expanding variadic templates packs in lambda functions, which is done in our unit testing framework). GitHub Actions have been adjusted accordingly.